### PR TITLE
Develop

### DIFF
--- a/src/animation/cycleanimation.cpp
+++ b/src/animation/cycleanimation.cpp
@@ -15,7 +15,6 @@ namespace PixelMaestro {
 	}
 
 	void CycleAnimation::update() {
-		map();
 		update_cycle(0, palette_->get_num_colors());
 	}
 }

--- a/src/core/colors.h
+++ b/src/core/colors.h
@@ -18,13 +18,13 @@ namespace PixelMaestro {
 			/// Stores an RGB definition of a color.
 			struct RGB {
 				/// The color's red value.
-				uint8_t r;
+				int16_t r;
 
 				/// The color's green value.
-				uint8_t g;
+				int16_t g;
 
 				/// The color's blue value.
-				uint8_t b;
+				int16_t b;
 
 				/**
 				 * Constructor. Defaults to black if no other parameters are provided.


### PR DESCRIPTION
When using 2.x, my led strip fades to white and stays there.  This appears to be due to the pixel class switching to  using a Colors::RGB instance for steps_, while the difference in two colors may be a negative value.

Additionally, the cycle animation appears to have an extra map call, since the animation class automatically shifts through the color palette.